### PR TITLE
Add pkg-config support for gmock

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -27,6 +27,9 @@ if (COMMAND pre_project_set_up_hermetic_build)
   pre_project_set_up_hermetic_build()
 endif()
 
+# pkg-config support
+configure_file("gmock.pc.in" "gmock.pc" @ONLY)
+
 ########################################################################
 #
 # Project-wide settings
@@ -107,6 +110,10 @@ install(TARGETS gmock gmock_main
   DESTINATION lib)
 install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
   DESTINATION include)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/gmock.pc"
+   DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig/"
+)
 
 ########################################################################
 #

--- a/googlemock/gmock.pc.in
+++ b/googlemock/gmock.pc.in
@@ -1,0 +1,9 @@
+Name: libgmock
+Version: 1.7.0
+Description: Google's framework for writing C++ tests on a variety of platforms
+
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+libdir=${prefix}/lib
+Cflags:-I${includedir}/gmock
+Libs: -L${libdir} -lgmock -lgmock_main


### PR DESCRIPTION
Hi,

This is the pkg-config support for gmock taken from ops.

JD
